### PR TITLE
Add OSError except for files that can not be written

### DIFF
--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -48,9 +48,7 @@ def download_file(url, dest, on_progress=None):
         with tqdm(total=total, unit='B', unit_scale=True, unit_divisor=1024) as bar:
             for data in response.iter_content(chunk_size=download_chunk_size):
                 current += len(data)
-                try:
-                    pos = f.write(data)
-
+                pos = f.write(data)
                 bar.update(pos)
                 if on_progress is not None:
                     should_stop = on_progress(current, total, start_time)

--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -48,7 +48,9 @@ def download_file(url, dest, on_progress=None):
         with tqdm(total=total, unit='B', unit_scale=True, unit_divisor=1024) as bar:
             for data in response.iter_content(chunk_size=download_chunk_size):
                 current += len(data)
-                pos = f.write(data)
+                try:
+                    pos = f.write(data)
+
                 bar.update(pos)
                 if on_progress is not None:
                     should_stop = on_progress(current, total, start_time)
@@ -56,6 +58,9 @@ def download_file(url, dest, on_progress=None):
                         raise Exception('Download cancelled')
         f.close()
         shutil.move(f.name, dest)
+    except OSError as e:
+       print(f"Could not write the preview file to {dst_dir}")
+       print(e)
     finally:
         f.close()
         if os.path.exists(f.name):


### PR DESCRIPTION
Handle the case where a directory or file can not be accessed.

Current experience

```
Exception in thread Thread-12 (load_previews):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/mnt/900/builds/stable-diffusion-webui/extensions/sd_civitai_extension/scripts/previews.py", line 48, in load_previews
    civitai.update_resource_preview(hash, image_url)
  File "/mnt/900/builds/stable-diffusion-webui/extensions/sd_civitai_extension/civitai/lib.py", line 395, in update_resource_preview
    download_file(preview_url, preview_path)
  File "/mnt/900/builds/stable-diffusion-webui/extensions/sd_civitai_extension/civitai/lib.py", line 51, in download_file
    pos = f.write(data)
  File "/usr/lib/python3.10/tempfile.py", line 483, in func_wrapper
    return func(*args, **kwargs)
OSError: [Errno 28] No space left on device
```

And will stop processing (I have a drive that is full, but my other drives have space).