### PR TITLE
Remove specific extension folder name dependency

### DIFF
--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -10,7 +10,7 @@ import glob
 from tqdm import tqdm
 from modules import shared, sd_models, sd_vae, hashes
 from modules.paths import models_path
-from extensions.sd_civitai_extension.civitai.models import Command, ResourceRequest
+from civitai.models import Command, ResourceRequest
 
 #region shared variables
 try:

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -4,8 +4,8 @@ from fastapi import FastAPI
 
 from modules import script_callbacks as script_callbacks
 
-import extensions.sd_civitai_extension.civitai.lib as civitai
-from extensions.sd_civitai_extension.civitai.models import GenerateImageRequest, ResourceRequest
+import civitai.lib as civitai
+from civitai.models import GenerateImageRequest, ResourceRequest
 
 def civitaiAPI(demo: gr.Blocks, app: FastAPI):
     @app.get('/civitai/v1/link-status')

--- a/scripts/gen_hashing.py
+++ b/scripts/gen_hashing.py
@@ -2,7 +2,7 @@ import json
 import re
 import os
 
-import extensions.sd_civitai_extension.civitai.lib as civitai
+import civitai.lib as civitai
 from modules import script_callbacks, sd_vae, shared
 
 additional_network_type_map = {

--- a/scripts/link.py
+++ b/scripts/link.py
@@ -6,8 +6,8 @@ import gradio as gr
 import socketio
 import os
 
-import extensions.sd_civitai_extension.civitai.lib as civitai
-from extensions.sd_civitai_extension.civitai.models import Command, CommandActivitiesList, CommandResourcesAdd, CommandActivitiesCancel, CommandResourcesList, CommandResourcesRemove, ErrorPayload, JoinedPayload, RoomPresence, UpgradeKeyPayload
+import civitai.lib as civitai
+from civitai.models import Command, CommandActivitiesList, CommandResourcesAdd, CommandActivitiesCancel, CommandResourcesList, CommandResourcesRemove, ErrorPayload, JoinedPayload, RoomPresence, UpgradeKeyPayload
 
 from modules import shared, sd_models, script_callbacks, hashes
 

--- a/scripts/pasted.py
+++ b/scripts/pasted.py
@@ -1,4 +1,4 @@
-import extensions.sd_civitai_extension.civitai.lib as civitai
+import civitai.lib as civitai
 
 from modules import shared, script_callbacks
 

--- a/scripts/previews.py
+++ b/scripts/previews.py
@@ -2,7 +2,7 @@ from typing import List
 import gradio as gr
 import threading
 
-import extensions.sd_civitai_extension.civitai.lib as civitai
+import civitai.lib as civitai
 
 from modules import script_callbacks, shared
 

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -1,5 +1,5 @@
-import extensions.sd_civitai_extension.civitai.lib as civitai
-from extensions.sd_civitai_extension.scripts.link import on_civitai_link_key_changed
+import civitai.lib as civitai
+from scripts.link import on_civitai_link_key_changed
 
 from modules import shared, script_callbacks
 


### PR DESCRIPTION
Currently, the extension forces the user to put it in a folder called `sd_civitai_extension` or it will be unable to load it's modules. This removes that and allows the user to put it in a folder of their choice ex. `civitiai-extension`.