### PR TITLE
Modify requirement install and add manually load previews

### DIFF
--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -27,6 +27,7 @@ cache_key = 'civitai'
 #region Utils
 def log(message):
     """Log a message to the console."""
+    if not shared.opts.data.get('civitai_link_logging', True): return
     print(f'Civitai: {message}')
 
 def download_file(url, dest, on_progress=None):

--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -46,7 +46,7 @@ def download_file(url, dest, on_progress=None):
 
     try:
         current = 0
-        with tqdm(total=total, unit='B', unit_scale=True, unit_divisor=1024) as bar:
+        with tqdm(total=total, unit='B', unit_scale=True, unit_divisor=1024, disable=not shared.opts.data.get('civitai_link_logging', True)) as bar:
             for data in response.iter_content(chunk_size=download_chunk_size):
                 current += len(data)
                 pos = f.write(data)

--- a/install.py
+++ b/install.py
@@ -4,7 +4,8 @@ import sys
 
 import git
 
-from launch import run
+import launch
+from modules import shared
 
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
 
@@ -36,8 +37,8 @@ def check_versions():
     # Loop through reqs and check if installed
     for req in reqs_dict:
         available = is_package_installed(req, reqs_dict[req])
-        if available: print(f"[+] {req} version {reqs_dict[req]} installed.")
-        else : print(f"[!] {req} version {reqs_dict[req]} NOT installed.")
+        if available: print(f"[+]Civitai Link requirement: {req} version {reqs_dict[req]} installed.")
+        else : print(f"[!]Civitai Link requirement: {req} version {reqs_dict[req]} NOT installed.")
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 revision = ""
@@ -51,29 +52,27 @@ try:
 except:
     pass
 
-print("")
-print("#######################################################################################################")
-print("Initializing Civitai Link")
-print("If submitting an issue on github, please provide the below text for debugging purposes:")
-print("")
-print(f"Python revision: {sys.version}")
-print(f"Civitai Link revision: {revision}")
-print(f"SD-WebUI revision: {app_revision}")
-print("")
+if shared.opts.data.get('civitai_link_logging', True):
+    print("")
+    print("#######################################################################################################")
+    print("Initializing Civitai Link")
+    print("If submitting an issue on github, please provide the below text for debugging purposes:")
+    print("")
+    print(f"Python revision: {sys.version}")
+    print(f"Civitai Link revision: {revision}")
+    print(f"SD-WebUI revision: {app_revision}")
+    print("")
+
 civitai_skip_install = os.environ.get('CIVITAI_SKIP_INSTALL', False)
 
-try:
-    requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
-    if requirements_file == req_file:
-        civitai_skip_install = True
-except:
-    pass
-
 if not civitai_skip_install:
-    name = "Civitai Link"
-    run(f'"{sys.executable}" -m pip install -r "{req_file}"', f"Checking {name} requirements...",
-        f"Couldn't install {name} requirements.")
+    with open(req_file) as file:
+        for lib in file:
+            lib = lib.strip()
+            if not launch.is_installed(lib):
+                launch.run_pip(f"install {lib}", f"Civitai Link requirement: {lib}")
 
 check_versions()
-print("")
-print("#######################################################################################################")
+if shared.opts.data.get('civitai_link_logging', True):
+    print("")
+    print("#######################################################################################################")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-socketio[client]==5.7.2
+python-socketio[client]>=5.7.2

--- a/scripts/previews.py
+++ b/scripts/previews.py
@@ -1,4 +1,5 @@
 from typing import List
+from datetime import datetime
 import gradio as gr
 import threading
 
@@ -7,9 +8,10 @@ import civitai.lib as civitai
 from modules import script_callbacks, shared
 
 previewable_types = ['LORA', 'Hypernetwork', 'TextualInversion', 'Checkpoint']
+previews_update_info = ["Press Refresh button on the right to manully load previews"]
+
 def load_previews():
-    download_missing_previews = shared.opts.data.get('civitai_download_previews', True)
-    if not download_missing_previews: return
+    previews_update_info[0] = datetime.now().strftime("%Y/%m/%d/ %H:%M:%S")
     nsfw_previews = shared.opts.data.get('civitai_nsfw_previews', True)
 
     civitai.log(f"Check resources for missing preview images")
@@ -29,10 +31,12 @@ def load_previews():
             results.extend(civitai.get_all_by_hash(batch))
     except:
         civitai.log("Failed to fetch preview images from Civitai")
+        previews_update_info[0] += " - Failed to fetch preview images from Civitai"
         return
 
     if len(results) == 0:
-        civitai.log("No preview images found on Civitai")
+        civitai.log("No new preview image found on Civitai")
+        previews_update_info[0] += " - No new preview image found on Civitai"
         return
 
     civitai.log(f"Found {len(results)} hash matches")
@@ -54,10 +58,16 @@ def load_previews():
             updated += 1
 
     civitai.log(f"Updated {updated} preview images")
+    previews_update_info[0] += f" - Found and updated {updated} of {len(missing_previews)} missing preview images"
 
+def load_previews_on_startup():
+    download_missing_previews = shared.opts.data.get('civitai_on_startup_download_previews', False)
+    if not download_missing_previews: return
+    load_previews()
+    
 # Automatically pull model with corresponding hash from Civitai
 def start_load_previews(demo: gr.Blocks, app):
-    thread = threading.Thread(target=load_previews)
+    thread = threading.Thread(target=load_previews_on_startup)
     thread.start()
 
 script_callbacks.on_app_started(start_load_previews)

--- a/scripts/previews.py
+++ b/scripts/previews.py
@@ -8,7 +8,7 @@ import civitai.lib as civitai
 from modules import script_callbacks, shared
 
 previewable_types = ['LORA', 'Hypernetwork', 'TextualInversion', 'Checkpoint']
-previews_update_info = ["Press Refresh button on the right to manully load previews"]
+previews_update_info = ["Press Refresh button on the right to manually load previews"]
 
 def load_previews():
     previews_update_info[0] = datetime.now().strftime("%Y/%m/%d/ %H:%M:%S")

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -1,16 +1,27 @@
+import sys
+import os
+import gradio as gr
+
+cwd = os.getcwd()
+utils_dir = os.path.join(cwd, 'extensions', 'sd_civitai_extension', 'scripts')
+sys.path.extend([utils_dir])
+
 from civitai.link import on_civitai_link_key_changed
+from previews import load_previews,previews_update_info
+
 from modules import shared, script_callbacks
+
 
 def on_ui_settings():
     section = ('civitai_link', "Civitai")
     shared.opts.add_option("civitai_link_key", shared.OptionInfo("", "Your Civitai Link Key", section=section, onchange=on_civitai_link_key_changed))
     shared.opts.add_option("civitai_link_logging", shared.OptionInfo(True, "Show Civitai Link events in the console", section=section))
     shared.opts.add_option("civitai_api_key", shared.OptionInfo("", "Your Civitai API Key", section=section))
-    shared.opts.add_option("civitai_download_previews", shared.OptionInfo(True, "Download missing preview images on startup", section=section))
+    shared.opts.add_option("civitai_on_startup_download_previews", shared.OptionInfo(False, "Download missing preview images on startup", section=section))
     shared.opts.add_option("civitai_nsfw_previews", shared.OptionInfo(False, "Download NSFW (adult) preview images", section=section))
     shared.opts.add_option("civitai_download_missing_models", shared.OptionInfo(True, "Download missing models upon reading generation parameters from prompt", section=section))
     shared.opts.add_option("civitai_hashify_resources", shared.OptionInfo(True, "Include resource hashes in image metadata (for resource auto-detection on Civitai)", section=section))
     shared.opts.add_option("civitai_folder_lora", shared.OptionInfo("", "LoRA directory (if not default)", section=section))
-
+    shared.opts.add_option("civitai_manual_download_previews", shared.OptionInfo(previews_update_info[0], "Last manually load time", gr.Dropdown, lambda: {"choices": previews_update_info},refresh=load_previews,section=section))
 
 script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -22,6 +22,6 @@ def on_ui_settings():
     shared.opts.add_option("civitai_download_missing_models", shared.OptionInfo(True, "Download missing models upon reading generation parameters from prompt", section=section))
     shared.opts.add_option("civitai_hashify_resources", shared.OptionInfo(True, "Include resource hashes in image metadata (for resource auto-detection on Civitai)", section=section))
     shared.opts.add_option("civitai_folder_lora", shared.OptionInfo("", "LoRA directory (if not default)", section=section))
-    shared.opts.add_option("civitai_manual_download_previews", shared.OptionInfo(previews_update_info[0], "Last manually load time", gr.Dropdown, lambda: {"choices": previews_update_info},refresh=load_previews,section=section))
+    shared.opts.add_option("civitai_manually_download_previews", shared.OptionInfo(previews_update_info[0], "Last manually load time", gr.Dropdown, lambda: {"choices": previews_update_info},refresh=load_previews,section=section))
 
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
- Add `civitai_link_logging` checks in `lib.py` and `install.py`, since sometimes the info spams the console.
- Modify the install process using `launch.is_installed` and `launch.run_pip` instead of directly running `pip` commands.
- Add a manual load section in the settings tab. I think it's common for people to turn off the `download on startup` and load previews manually after they download some LoRAs. (I used `gradio.Dropdown` here since I didn't find other ways, please let me know if anyone knows better ways)

![image](https://user-images.githubusercontent.com/22171828/227824446-3150c543-1ad2-417d-809a-b5f26685339c.png)
![image](https://user-images.githubusercontent.com/22171828/227823774-ea84dee5-02a4-4ea9-a5b8-26076603ff10.png)
