### PR TITLE
Ensure to raise change events and save on upgraded key

### DIFF
--- a/civitai/link.py
+++ b/civitai/link.py
@@ -196,8 +196,10 @@ def on_upgrade_key(payload: UpgradeKeyPayload):
     global upgraded_key
 
     log("Link Key upgraded")
-    shared.opts.data['civitai_link_key'] = payload['key']
     upgraded_key = payload['key']
+
+    shared.opts.set('civitai_link_key',  upgraded_key)
+    shared.opts.save(shared.config_filename)
 
 @sio.on('error')
 def on_error(payload: ErrorPayload):


### PR DESCRIPTION
1. By calling `shared.opts.set` we ensure that `onchange` is been invoked and therefore that the client will join the new room
2. By calling `shared.opts.save` we ensure that the upgraded key gets persisted