### PR TITLE
hash support for LoRA Block Weight extension

### DIFF
--- a/scripts/gen_hashing.py
+++ b/scripts/gen_hashing.py
@@ -9,7 +9,7 @@ additional_network_type_map = {
     'lora': 'LORA',
     'hypernet': 'Hypernetwork'
 }
-additional_network_pattern = r'<(lora|hypernet):([a-zA-Z0-9_\.\-]+):([0-9.]+)>'
+additional_network_pattern = r'<(lora|hypernet):([a-zA-Z0-9_\.\-]+):([0-9.]+)(?:[:].*)?>'
 model_hash_pattern = r'Model hash: ([0-9a-fA-F]{10})'
 
 # Automatically pull model with corresponding hash from Civitai


### PR DESCRIPTION
this is a quick hack to support LoRA Block Weight extension use `<lora:FooBar:0.5:BlahBlah...>` extended syntax.