### PR TITLE
Fetch info json from civitai and write it if it doesn't exist

### DIFF
--- a/civitai/lib.py
+++ b/civitai/lib.py
@@ -174,7 +174,7 @@ def has_preview(filename: str):
     return os.path.isfile(os.path.splitext(filename)[0] + '.preview.png')
 
 def has_info(filename: str):
-    return os.path.isfile(os.path.splitext(filename)[0] + '.info.json')
+    return os.path.isfile(os.path.splitext(filename)[0] + '.json')
 
 def get_resources_in_folder(type, folder, exts=[], exts_exclude=[]):
     resources = []

--- a/scripts/info.py
+++ b/scripts/info.py
@@ -1,0 +1,90 @@
+from typing import List
+import gradio as gr
+import threading
+import json
+from pathlib import Path
+
+import civitai.lib as civitai
+
+from modules import script_callbacks, shared
+
+actionable_types = ['LORA', 'LoCon', 'Hypernetwork', 'TextualInversion', 'Checkpoint']
+
+
+def load_info():
+    download_missing_previews = shared.opts.data.get('civitai_download_triggers', True)
+    if not download_missing_previews:
+        return
+
+    civitai.log("Check resources for missing info files")
+    resources = civitai.load_resource_list()
+    resources = [r for r in resources if r['type'] in actionable_types]
+
+    # get all resources that have no info files
+    missing_info = [r for r in resources if r['hasInfo'] is False]
+    civitai.log(f"Found {len(missing_info)} resources missing info files")
+    hashes = [r['hash'] for r in missing_info]
+
+    # split hashes into batches of 100 and fetch into results
+    results = []
+    try:
+        for i in range(0, len(hashes), 100):
+            batch = hashes[i:i + 100]
+            results.extend(civitai.get_all_by_hash(batch))
+    except:
+        civitai.log("Failed to fetch info from Civitai")
+        return
+
+    if len(results) == 0:
+        civitai.log("No info found on Civitai")
+        return
+
+    civitai.log(f"Found {len(results)} hash matches")
+
+    # update the resources with the new info
+    updated = 0
+    for r in results:
+        if (r is None):
+            continue
+
+        for file in r['files']:
+            if not 'hashes' in file or not 'SHA256' in file['hashes']: 
+                continue
+            file_hash = file['hashes']['SHA256']
+            if file_hash.lower() not in hashes: 
+                continue
+
+            if "SD 1" in r['baseModel']:
+                sd_version = "SD1"
+            elif "SD 2" in r['baseModel']:
+                sd_version = "SD2"
+            elif "SDXL" in r['baseModel']:
+                sd_version = "SDXL"
+            else:
+                sd_version = "unknown"
+            data = {
+                "description": r['description'],
+                "sd version": sd_version,
+                "activation text": ", ".join(r['trainedWords']),
+                "preferred weight": 0.8,
+                "notes": "",
+            }
+            
+            matches = [resource for resource in missing_info if file_hash.lower() == resource['hash']]
+            if len(matches) == 0: 
+                continue
+
+            for resource in matches:
+                Path(resource['path']).with_suffix(".json").write_text(json.dumps(data, indent=4))
+            updated += 1
+
+    civitai.log(f"Updated {updated} info files")
+
+
+# Automatically pull model with corresponding hash from Civitai
+def start_load_info(demo: gr.Blocks, app):
+    thread = threading.Thread(target=load_info)
+    thread.start()
+
+
+script_callbacks.on_app_started(start_load_info)

--- a/scripts/settings.py
+++ b/scripts/settings.py
@@ -7,6 +7,7 @@ def on_ui_settings():
     shared.opts.add_option("civitai_link_logging", shared.OptionInfo(True, "Show Civitai Link events in the console", section=section))
     shared.opts.add_option("civitai_api_key", shared.OptionInfo("", "Your Civitai API Key", section=section))
     shared.opts.add_option("civitai_download_previews", shared.OptionInfo(True, "Download missing preview images on startup", section=section))
+    shared.opts.add_option("civitai_download_triggers", shared.OptionInfo(True, "Download missing activation triggers on startup", section=section))
     shared.opts.add_option("civitai_nsfw_previews", shared.OptionInfo(False, "Download NSFW (adult) preview images", section=section))
     shared.opts.add_option("civitai_download_missing_models", shared.OptionInfo(True, "Download missing models upon reading generation parameters from prompt", section=section))
     shared.opts.add_option("civitai_hashify_resources", shared.OptionInfo(True, "Include resource hashes in image metadata (for resource auto-detection on Civitai)", section=section))


### PR DESCRIPTION
Now that Automatic1111 has a built in way to supply activation triggers, I thought it would be nice if the CivitAI extension would fill those in automatically. It only takes effect if the json file doesn't exist, so it shouldn't spam CivitAI servers on every startup more that it already does for images.