### PR TITLE
Don't force "preferred weight: 0.8" in initial info json

### DIFF
--- a/scripts/info.py
+++ b/scripts/info.py
@@ -66,7 +66,6 @@ def load_info():
                 "description": r['description'],
                 "sd version": sd_version,
                 "activation text": ", ".join(r['trainedWords']),
-                "preferred weight": 0.8,
                 "notes": "",
             }
             


### PR DESCRIPTION
automatic1111 already has a setting for global default extra network weight on the Extra Networks tab, `extra_networks_default_multiplier`.
The plugin shouldn't force a hardcoded initial/default value for extra network weight, plus setting it for all models defeats the purpose of the existing global setting.