### PR TITLE
Add troubleshooting note regarding `--no-hashing` a1111 launch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ https://user-images.githubusercontent.com/607609/234462691-ecd578cc-b0ec-49e4-8e
 4. Press install and wait for it to complete
 5. **Restart Automatic1111** (Reloading the UI will not install the necessary requirements)
 
+***note:*** for the correct usage of this extension, make sure to **remove** the `--no-hashing` launch option from Automatic 1111 (if you are using it) as this extension relies on hash information provided it.
+
 ### Manually
 1. Download the repo using any method (zip download or cloning)
 ```sh
@@ -37,6 +39,9 @@ py install.py
 # OR
 python install.py
 ```
+
+***note:*** for the correct usage of this extension, make sure to **remove** the `--no-hashing` launch option from Automatic 1111 (if you are using it) as this extension relies on hash information provided it.
+
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ python install.py
 
 ***note:*** for the correct usage of this extension, make sure to **remove** the `--no-hashing` launch option from Automatic 1111 (if you are using it) as this extension relies on hash information provided it.
 
-
 ## Frequently Asked Questions
 
 ### What the Civitai Link Key? Where do I get it?


### PR DESCRIPTION
Given that blake3 attempts were discontinued in favor of using sha256 for the hash computation of resources, the `--no-hashing` launch option available in automatic 1111 results in the extension not recognizing several resources because their hash is not present (and raising exceptions since the hash value returned is None).

This launch option is incompatible with the current way the extension works.