### PR TITLE
Bugfix for #127.

### DIFF
--- a/scripts/previews.py
+++ b/scripts/previews.py
@@ -48,8 +48,9 @@ def load_previews():
             if hash.lower() not in hashes: continue
             images = r['images']
             if (nsfw_previews is False): images = [i for i in images if i['nsfw'] is False]
-            if (len(images) == 0): continue
-            image_url = images[0]['url']
+            image_urls = [image['url'] for image in images if (image['type'] == 'image')]
+            if (len(image_urls) == 0): continue
+            image_url = image_urls[0]
             civitai.update_resource_preview(hash, image_url)
             updated += 1
 


### PR DESCRIPTION
Video previews cannot be displayed in webui. The first non video's url is grabbed instead.