### PR TITLE
Update install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,9 +4,16 @@ import sys
 
 import git
 
-from launch import run
-
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
+
+def run(command, desc=None, errdesc=None):
+    try:
+        if desc:
+            print(f"[Info] {desc}")
+        subprocess.check_call(command, shell=True)
+    except subprocess.CalledProcessError as e:
+        print(f"[Error] {errdesc or 'Subprocess failed'}: {e}")
+        sys.exit(1)
 
 def is_package_installed(package_name, version):
     # strip [] from package name


### PR DESCRIPTION
Hi Civitai team,

This PR replaces the dependency on launch.run() with a local run() function to improve compatibility with forks of SD-WebUI such as Forge and other secure environments that disable or restrict access to internal A1111 modules (e.g. with --disable-extension-access).

**Changes:**
Replaces from launch import run with a standalone function that wraps subprocess.check_call

Maintains the same output behavior (optional desc and errdesc handling)

Prevents AssertionError: extension access disabled because of command line flags on Forge-based installs

**Why this is helpful:**
Allows the extension to function on forks where launch.py is inaccessible or restricted

Avoids breaking startup due to missing internal methods

Keeps the extension self-contained and more portable

Thanks for your awesome work on Civitai Link — happy to support compatibility with the broader SD community!

Best,
Kittensx